### PR TITLE
Exit start() early if no function provided

### DIFF
--- a/Interval.js
+++ b/Interval.js
@@ -7,10 +7,14 @@ class Interval {
     }
 
     start(...args) {
+        if (typeof this.fn !== 'function')
+            return console.error('No function provided');
+        
         this.id = setInterval((...args) => {
             this.count++;
             this.fn(...args);
         }, this.delay, ...args);
+        
         this.running = true;
     }
 


### PR DESCRIPTION
Avoids trying to call an undefined function on a loop